### PR TITLE
Make messier-61-graph a Standalone NPM Package

### DIFF
--- a/packages/messier-61-graph/package.json
+++ b/packages/messier-61-graph/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@paion-data/messier-61-graph",
+  "version": "0.1.0",
+  "main": "dist/messier-61-graph.js",
+  "engines": {
+    "node": ">=16.0.0 <18.0.0"
+  },
+  "author": "Paion Data Development Team",
+  "license": "Apache-2.0",
+  "typings": "dist/messier-61-graph.d.ts",
+  "scripts": {
+    "build": "rollup -c --failAfterWarnings",
+    "test": "tsc --noEmit",
+    "prepublishOnly": "npm run test && npm run build"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/paion-data/Messier-61.git"
+  },
+  "files": [
+    "dist",
+    "package.json",
+    "README.md",
+    "LICENSE"
+  ],
+  "devDependencies": {},
+  "dependencies": {},
+  "peerDependencies": {}
+}

--- a/packages/messier-61-graph/tsconfig.json
+++ b/packages/messier-61-graph/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "jsx": "react",
+    "sourceMap": true,
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "node"
+  },
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}


### PR DESCRIPTION
Changelog
---------

### Added

- Following [Neo4J Browser arc package](https://github.com/QubitPi/neo4j-browser/tree/master/src/neo4j-arc), Messier-61 now have its own graphing module turned into a dedicated package

### Changed

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

* [x] Test
* [x] Self-review
* [x] Documentation
